### PR TITLE
Recover buffer position after reset

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": []
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-    "files.associations": {
-        "xmemory": "c",
-        "adc.h": "c",
-        "app_lorawan.h": "c"
-    }
+  "files.associations": {
+    "xmemory": "c",
+    "adc.h": "c",
+    "app_lorawan.h": "c"
+  }
 }

--- a/stm32/Src/examples/example_fram.c
+++ b/stm32/Src/examples/example_fram.c
@@ -1,0 +1,245 @@
+/* USER CODE BEGIN Header */
+/**
+ ******************************************************************************
+ * @file           : main.c
+ * @brief          : Main program body
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2023 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
+/* USER CODE END Header */
+/* Includes ------------------------------------------------------------------*/
+#include "main.h"
+#include "adc.h"
+#include "dma.h"
+#include "i2c.h"
+#include "app_lorawan.h"
+#include "tim.h"
+#include "usart.h"
+#include "gpio.h"
+
+/* Private includes ----------------------------------------------------------*/
+/* USER CODE BEGIN Includes */
+#include <stdio.h>
+
+#include "sys_app.h"
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "ads.h"
+#include "sdi12.h"
+#include "phytos31.h"
+#include "rtc.h"
+#include "sensors.h"
+#include "fram.h"  
+/* USER CODE END Includes */
+
+/* Private typedef -----------------------------------------------------------*/
+/* USER CODE BEGIN PTD */
+
+/* USER CODE END PTD */
+
+/* Private define ------------------------------------------------------------*/
+/* USER CODE BEGIN PD */
+
+/* USER CODE END PD */
+
+/* Private macro -------------------------------------------------------------*/
+/* USER CODE BEGIN PM */
+
+/* USER CODE END PM */
+
+/* Private variables ---------------------------------------------------------*/
+
+/* USER CODE BEGIN PV */
+uint16_t read_addr = 0;
+uint16_t write_addr = 0;
+uint16_t buffer_len = 0;
+/* USER CODE END PV */
+
+/* Private function prototypes -----------------------------------------------*/
+void SystemClock_Config(void);
+/* USER CODE BEGIN PFP */
+
+/* USER CODE END PFP */
+
+/* Private user code ---------------------------------------------------------*/
+/* USER CODE BEGIN 0 */
+
+/* USER CODE END 0 */
+
+/**
+  * @brief  The application entry point.
+  * @retval int
+  */
+int main(void)
+{
+  /* USER CODE BEGIN 1 */
+
+  /* USER CODE END 1 */
+
+  /* MCU Configuration--------------------------------------------------------*/
+
+  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+  HAL_Init();
+
+  /* USER CODE BEGIN Init */
+
+  /* USER CODE END Init */
+
+  /* Configure the system clock */
+  SystemClock_Config();
+
+  /* USER CODE BEGIN SysInit */
+
+  /* USER CODE END SysInit */
+
+  /* Initialize all configured peripherals */
+  MX_GPIO_Init();
+  MX_DMA_Init();
+  MX_ADC_Init();
+  MX_USART1_UART_Init();
+  MX_LoRaWAN_Init();
+  MX_I2C2_Init();
+  MX_USART2_UART_Init();
+  MX_TIM1_Init();
+  /* USER CODE BEGIN 2 */
+  ADC_init();
+  MX_RTC_Init();
+  SensorsInit();
+
+  // Load the buffer state from FRAM
+  load_buffer_state(&read_addr, &write_addr, &buffer_len);
+
+   /* Print the initial buffer state */
+    printf("Initial buffer state:\n");
+    printf("  Read address: 0x%04X\n", read_addr);
+    printf("  Write address: 0x%04X\n", write_addr);
+    printf("  Buffer length: %d\n", buffer_len);
+
+  // Debug message, gets printed after init code
+  APP_PRINTF("Soil Power Sensor Wio-E5 firmware, compiled on %s %s\n", __DATE__, __TIME__);
+
+  // configure sensors
+  SensorsAdd(ADC_measure);
+  //SensorsAdd(SDI12_Teros12Measure);
+  //SensorsAdd(Phytos31_measure);
+
+  /* Modify the buffer state */
+    read_addr += 10;
+    write_addr += 20;
+    buffer_len += 30;
+
+  // Store the buffer state in FRAM
+  store_buffer_state(read_addr, write_addr, buffer_len);
+
+  /* USER CODE END 2 */
+
+  /* Infinite loop */
+  /* USER CODE BEGIN WHILE */
+  while (1)
+  {
+    /* USER CODE END WHILE */
+    MX_LoRaWAN_Process();
+
+    /* USER CODE BEGIN 3 */
+  }
+  /* USER CODE END 3 */
+}
+
+/**
+  * @brief System Clock Configuration
+  * @retval None
+  */
+void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+
+  /** Configure LSE Drive Capability
+  */
+  HAL_PWR_EnableBkUpAccess();
+  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
+
+  /** Configure the main internal regulator output voltage
+  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /** Initializes the CPU, AHB and APB buses clocks
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE|RCC_OSCILLATORTYPE_MSI;
+  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+  {
+    Error_Handler();
+  }
+
+  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
+                              |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
+                              |RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
+  {
+    Error_Handler();
+  }
+  HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1);
+}
+
+/* USER CODE BEGIN 4 */
+
+/* USER CODE END 4 */
+
+/**
+  * @brief  This function is executed in case of error occurrence.
+  * @retval None
+  */
+void Error_Handler(void)
+{
+  /* USER CODE BEGIN Error_Handler_Debug */
+  // char error[30];
+  // int error_len = sprintf(error, "Error!  HAL Status: %d\n", rc);
+  // HAL_UART_Transmit(&huart1, (const uint8_t *)error, error_len, 1000);
+
+  /* User can add his own implementation to report the HAL error return state */
+  __disable_irq();
+  while (1)
+  {
+  }
+  /* USER CODE END Error_Handler_Debug */
+}
+
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  Reports the name of the source file and the source line number
+  *         where the assert_param error has occurred.
+  * @param  file: pointer to the source file name
+  * @param  line: assert_param error line source number
+  * @retval None
+  */
+void assert_failed(uint8_t *file, uint32_t line)
+{
+  /* USER CODE BEGIN 6 */
+  /* User can add his own implementation to report the file name and line number,
+     ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+  /* USER CODE END 6 */
+}
+#endif /* USE_FULL_ASSERT */

--- a/stm32/Src/main.c
+++ b/stm32/Src/main.c
@@ -127,7 +127,7 @@ int main(void)
   //SensorsAdd(SDI12_Teros12Measure);
   //SensorsAdd(Phytos31_measure);
 
-  // Store the initial buffer state in FRAM
+  // Store the buffer state in FRAM
   store_buffer_state(read_addr, write_addr, buffer_len);
 
   /* USER CODE END 2 */
@@ -177,7 +177,7 @@ void SystemClock_Config(void)
 
   /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
   */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_HCLK
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
                               |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
                               |RCC_CLOCKTYPE_PCLK2;
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;

--- a/stm32/Src/main.c
+++ b/stm32/Src/main.c
@@ -39,6 +39,7 @@
 #include "phytos31.h"
 #include "rtc.h"
 #include "sensors.h"
+#include "fram.h"  
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -59,7 +60,9 @@
 /* Private variables ---------------------------------------------------------*/
 
 /* USER CODE BEGIN PV */
-
+uint16_t read_addr = 0;
+uint16_t write_addr = 0;
+uint16_t buffer_len = 0;
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -113,6 +116,9 @@ int main(void)
   MX_RTC_Init();
   SensorsInit();
 
+  // Load the buffer state from FRAM
+  load_buffer_state(&read_addr, &write_addr, &buffer_len);
+
   // Debug message, gets printed after init code
   APP_PRINTF("Soil Power Sensor Wio-E5 firmware, compiled on %s %s\n", __DATE__, __TIME__);
 
@@ -121,6 +127,8 @@ int main(void)
   //SensorsAdd(SDI12_Teros12Measure);
   //SensorsAdd(Phytos31_measure);
 
+  // Store the initial buffer state in FRAM
+  store_buffer_state(read_addr, write_addr, buffer_len);
 
   /* USER CODE END 2 */
 
@@ -169,7 +177,7 @@ void SystemClock_Config(void)
 
   /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
   */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_HCLK
                               |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
                               |RCC_CLOCKTYPE_PCLK2;
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;

--- a/stm32/lib/fram/include/fram.h
+++ b/stm32/lib/fram/include/fram.h
@@ -119,6 +119,25 @@ HAL_StatusTypeDef ConfigureSettings(configuration c);
  */
 configuration ReadSettings(void);
 
+/**
+ * @brief Stores the buffer state in FRAM.
+ *
+ * @param read_addr The current read address.
+ * @param write_addr The current write address.
+ * @param buffer_len The current buffer length.
+ */
+void store_buffer_state(uint16_t read_addr, uint16_t write_addr, uint16_t buffer_len);
+
+/**
+ * @brief Loads the buffer state from FRAM.
+ *
+ * @param read_addr Pointer to store the read address.
+ * @param write_addr Pointer to store the write address.
+ * @param buffer_len Pointer to store the buffer length.
+ */
+void load_buffer_state(uint16_t *read_addr, uint16_t *write_addr, uint16_t *buffer_len);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/stm32/lib/fram/src/fram.c
+++ b/stm32/lib/fram/src/fram.c
@@ -12,13 +12,17 @@ const uint16_t fram_read_mask = 0b1;
 /** Device address mask for write */
 const uint16_t fram_write_mask = 0b0;
 
+/** Define FRAM addresses for storing buffer state */
+#define FRAM_READ_ADDR 0x0000
+#define FRAM_WRITE_ADDR 0x0002
+#define FRAM_BUF_LEN_ADDR 0x0004
+
 /** Matrix representation of memory */
-typedef struct
-{
-  /** Page reference */
-  uint16_t page;
-  /** Segment address */
-  uint16_t seg;
+typedef struct {
+    /** Page reference */
+    uint16_t page;
+    /** Segment address */
+    uint16_t seg;
 } FramAddress;
 
 /**
@@ -31,98 +35,115 @@ typedef struct
  */
 FramAddress FramConvertAddrMem(uint16_t addr);
 
-FramStatus FramWrite(uint16_t addr, const uint8_t *data, uint8_t len)
-{
-  // Write byte array to memory
-  // NOTE write is performed a single byte at a time due to address
-  // configuration of the chip.
-  for (uint8_t *d = data; d < data+len; d++) {
-    FramAddress addr_mat = FramConvertAddrMem(addr);
+FramStatus FramWrite(uint16_t addr, const uint8_t *data, uint8_t len) {
+    // Write byte array to memory
+    // NOTE write is performed a single byte at a time due to address
+    // configuration of the chip.
+    for (uint8_t *d = data; d < data + len; d++) {
+        FramAddress addr_mat = FramConvertAddrMem(addr);
 
-    // check for out of memory
-    // pages are zero indexed
-    if (addr_mat.page > FRAM_PAGES-1) {
-      return FRAM_OUT_OF_RANGE;
+        // check for out of memory
+        // pages are zero indexed
+        if (addr_mat.page > FRAM_PAGES - 1) {
+            return FRAM_OUT_OF_RANGE;
+        }
+
+        // format the i2c address 
+        uint16_t i2c_addr = fram_i2c_addr | (addr_mat.page << 1) | fram_write_mask;
+
+        // Write byte to an address
+        // Can optimize by using continuous writes but needs to account for the
+        // change of address.
+        HAL_StatusTypeDef status;
+        status = HAL_I2C_Mem_Write(&hi2c2, i2c_addr, addr_mat.seg, I2C_MEMADD_SIZE_8BIT, d, 1, fram_timeout);
+
+        // return error if failed to write
+        if (status != HAL_OK) {
+            return FRAM_ERROR;
+        }
+
+        // increment address
+        ++addr;
     }
 
-    // format the i2c address 
-    uint16_t i2c_addr = fram_i2c_addr | (addr_mat.page << 1) | fram_write_mask;
+    return FRAM_OK;
+}
 
-    // Write byte to an address
-    // Can optimize by using continuous writes but needs to account for the
-    // change of address.
-    HAL_StatusTypeDef status;
-    status = HAL_I2C_Mem_Write(&hi2c2, i2c_addr, addr_mat.seg,
-                               I2C_MEMADD_SIZE_8BIT, d, 1, fram_timeout);
-    
-    // return error if failed to write
-    if (status != HAL_OK) {
-      return FRAM_ERROR;
+FramStatus FramRead(uint16_t addr, uint8_t len, uint8_t *data) {
+    // Write byte array to memory
+    // NOTE write is performed a single byte at a time due to address
+    // configuration of the chip.
+    for (uint8_t *d = data; d < data + len; d++) {
+        FramAddress addr_mat = FramConvertAddrMem(addr);
+
+        // check for out of memory
+        if (addr_mat.page >= FRAM_PAGES) {
+            return FRAM_OUT_OF_RANGE;
+        }
+        // format the i2c address 
+        uint16_t i2c_addr = fram_i2c_addr | (addr_mat.page << 1) | fram_read_mask;
+
+        // Read byte to data address
+        HAL_StatusTypeDef status;
+        status = HAL_I2C_Mem_Read(&hi2c2, i2c_addr, addr_mat.seg, I2C_MEMADD_SIZE_8BIT, d, 1, fram_timeout);
+
+        // return error if failed to write
+        if (status != HAL_OK) {
+            return FRAM_ERROR;
+        }
+
+        // increment address
+        ++addr;
     }
 
-    // increment address
-    ++addr;
-  }
-
-  return FRAM_OK;
+    return FRAM_OK;
 }
 
-FramStatus FramRead(uint16_t addr, uint8_t len, uint8_t *data)
-{
-  // Write byte array to memory
-  // NOTE write is performed a single byte at a time due to address
-  // configuration of the chip.
-  for (uint8_t *d = data; d < data+len; d++) {
-    FramAddress addr_mat = FramConvertAddrMem(addr);
+HAL_StatusTypeDef ConfigureSettings(configuration c) {
+    HAL_StatusTypeDef status = HAL_OK;
 
-    // check for out of memory
-    if (addr_mat.page >= FRAM_PAGES) {
-      return FRAM_OUT_OF_RANGE;
-    }
-    // format the i2c address 
-    uint16_t i2c_addr = fram_i2c_addr | (addr_mat.page << 1) | fram_read_mask;
+    // TODO implement user config write
 
-    // Read byte to data address
-    HAL_StatusTypeDef status;
-    status = HAL_I2C_Mem_Read(&hi2c2, i2c_addr, addr_mat.seg,
-                              I2C_MEMADD_SIZE_8BIT, d, 1, fram_timeout);
-
-    // return error if failed to write
-    if (status != HAL_OK) {
-      return FRAM_ERROR;
-    }
-
-    // increment address
-    ++addr;
-  }
-
-  return FRAM_OK;
+    return status;
 }
 
-HAL_StatusTypeDef ConfigureSettings(configuration c)
-{
-  HAL_StatusTypeDef status = HAL_OK;
+configuration ReadSettings(void) {
+    configuration c;
 
-  // TODO implement user config write
+    // TODO implement user config read
 
-  return status;
+    return c;
 }
 
-configuration ReadSettings(void)
-{
-  configuration c;
+FramAddress FramConvertAddrMem(uint16_t addr) {
+    // convert flat address space to matrix
+    FramAddress addr_mat;
+    addr_mat.page = addr / FRAM_SEG_SIZE;
+    addr_mat.seg = addr % FRAM_SEG_SIZE;
 
-  // TODO implement user config read
-
-  return c;
+    return addr_mat;
 }
 
-FramAddress FramConvertAddrMem(uint16_t addr)
-{
-  // convert flat address space to matrix
-  FramAddress addr_mat;
-  addr_mat.page = addr / FRAM_SEG_SIZE;
-  addr_mat.seg = addr % FRAM_SEG_SIZE;
+// Define the buffer state storage address in FRAM
+#define BUFFER_STATE_ADDR 0x0000
 
-  return addr_mat;
+void store_buffer_state(uint16_t read_addr, uint16_t write_addr, uint16_t buffer_len) {
+    uint8_t data[6];
+    data[0] = (read_addr >> 8) & 0xFF;
+    data[1] = read_addr & 0xFF;
+    data[2] = (write_addr >> 8) & 0xFF;
+    data[3] = write_addr & 0xFF;
+    data[4] = (buffer_len >> 8) & 0xFF;
+    data[5] = buffer_len & 0xFF;
+
+    FramWrite(BUFFER_STATE_ADDR, data, sizeof(data));
+}
+
+void load_buffer_state(uint16_t *read_addr, uint16_t *write_addr, uint16_t *buffer_len) {
+    uint8_t data[6];
+    FramRead(BUFFER_STATE_ADDR, sizeof(data), data);
+
+    *read_addr = (data[0] << 8) | data[1];
+    *write_addr = (data[2] << 8) | data[3];
+    *buffer_len = (data[4] << 8) | data[5];
 }


### PR DESCRIPTION
---
name: Pull Request
about: Submit a pull request
title: ''Updated fram.c for issue #69"
labels: ''enhancement, stm32"
assignees: ''Kshitijpatil16"
reviewers: 'jmadden173'
---

**Name/Affiliation/Title**
Kshitij Patil, an electronics engineering student at Veermata Jijabai Technological Institute, Mumbai.

**Purpose of the PR**
To update the fram.c such that we can recover data on fram buffer after reset which solves issue #69.

**Development Environment**
OS: Windows 11, VS Code, Platformio version 3.3.3, Python 3.11.8

**Test Procedure**
Currently nothing.

**Additional Context**
- Added `store_buffer_state` and `load_buffer_state` functions to save and restore buffer state in FRAM.
- Modified `main.c` to store buffer state on shutdown and load it on startup.
- Defined FRAM addresses for buffer state and integrated read/write operations.