### PR TITLE
Change bme280 measurement mode to forced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,17 @@ firmware versions for a hardware version.
 
 ## [Unreleased]
 
-- Support for MB85RC1MT fram chip [#136](i136)
-- Support for bme280 sensor [#136](i136)
+### Added
 
-[i136](https://github.com/jlab-sensing/ENTS-node-firmware/issues/136)
+- Support for bme280 sensor [#87](i87), [#99](i99)
+- Support for MB85RC1MT fram chip [#136](i136)
+
+### Changed
+
+- Measurement mode of bme280 to forced [#99](i99)
+
+[i87]: https://github.com/jlab-sensing/ENTS-node-firmware/issues/87
+[i99]: https://github.com/jlab-sensing/ENTS-node-firmware/issues/99
 [i136]: https://github.com/jlab-sensing/ENTS-node-firmware/issues/136
 
 ## [2.2.0] - 2024-12-13

--- a/stm32/lib/bme280/src/bme280_sensor.c
+++ b/stm32/lib/bme280/src/bme280_sensor.c
@@ -69,7 +69,7 @@ BME280Status BME280Init(void) {
   }
 
   /* Always set the power mode after setting the configuration */
-  rslt = bme280_set_sensor_mode(BME280_POWERMODE_NORMAL, &dev);
+  rslt = bme280_set_sensor_mode(BME280_POWERMODE_FORCED, &dev);
   if (rslt != BME280_OK) {
     return rslt;
   }
@@ -86,7 +86,14 @@ BME280Status BME280Init(void) {
 BME280Status BME280MeasureAll(BME280Data *data) {
   int8_t rslt = BME280_E_NULL_PTR;
   uint8_t status_reg;
+ 
+  // trigger measurement
+  rslt = bme280_set_sensor_mode(BME280_POWERMODE_FORCED, &dev);
+  if (rslt != BME280_OK) {
+    return rslt;
+  }
 
+  // check the status
   rslt = bme280_get_regs(BME280_REG_STATUS, &status_reg, 1, &dev);
   if (rslt != BME280_OK) {
     return rslt;


### PR DESCRIPTION
**Name/Affiliation/Title**
John, UCSC, maintainer

**Purpose of the PR**
Fixes #99 

**Development Environment**
`OS: Linux spruce 6.8.2-arch2-1 #1 SMP PREEMPT_DYNAMIC Thu, 28 Mar 2024 17:06:35 +0000 x86_64 GNU/Linux`
Hardware version: 2.2.1
Software version: `99-bme280-reading-extreme-values`
Platformio Version: 6.1.15

**Test Procedure**
Run `example_bme280`

**Additional Context**
N/A

**Task List**

- [x] Update `CHANGELOG.md`
- [ ] Static code analysis passes
- [x] All environments can be built
- [x] All tests pass
- [x] Clear documentation for new code
- [x] Linting passes
- [ ] (If applicable) Version bump python library

**Relevant Issues**
Closes #99 