### PR TITLE
hotfix: Added example_teros12 environment

### DIFF
--- a/stm32/Src/examples/example_teros12.c
+++ b/stm32/Src/examples/example_teros12.c
@@ -1,0 +1,214 @@
+/**
+ * @brief Example teros12 code
+ * 
+ * Prints teros12 measurements over serial
+ *
+ * @author John Madden <jmadden173@pm.me>
+ * @date 2025-02-11
+ */
+
+#include "adc.h"
+#include "app_lorawan.h"
+#include "dma.h"
+#include "gpio.h"
+#include "i2c.h"
+#include "usart.h"
+
+/* Private includes ----------------------------------------------------------*/
+/* USER CODE BEGIN Includes */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sdi12.h"
+#include "sys_app.h"
+#include "teros21.h"
+
+/* USER CODE END Includes */
+
+/* Private typedef -----------------------------------------------------------*/
+/* USER CODE BEGIN PTD */
+
+/* USER CODE END PTD */
+
+/* Private define ------------------------------------------------------------*/
+/* USER CODE BEGIN PD */
+
+/* USER CODE END PD */
+
+/* Private macro -------------------------------------------------------------*/
+/* USER CODE BEGIN PM */
+
+/* USER CODE END PM */
+
+/* Private variables ---------------------------------------------------------*/
+
+/* USER CODE BEGIN PV */
+
+/* USER CODE END PV */
+
+/* Private function prototypes -----------------------------------------------*/
+void SystemClock_Config(void);
+/* USER CODE BEGIN PFP */
+/* USER CODE END PFP */
+
+/* Private user code ---------------------------------------------------------*/
+/* USER CODE BEGIN 0 */
+
+/* USER CODE END 0 */
+/**
+ * @brief  The application entry point.
+ * @retval int
+ */
+int main(void) {
+  /* USER CODE BEGIN 1 */
+
+  /* USER CODE END 1 */
+
+  /* MCU Configuration--------------------------------------------------------*/
+
+  /* Reset of all peripherals, Initializes the Flash interface and the Systick.
+   */
+  HAL_Init();
+
+  /* USER CODE BEGIN Init */
+  /* USER CODE END Init */
+
+  /* Configure the system clock */
+  SystemClock_Config();
+
+  /* USER CODE BEGIN SysInit */
+
+  /* USER CODE END SysInit */
+
+  /* Initialize all configured peripherals */
+  MX_GPIO_Init();
+  MX_DMA_Init();
+  MX_USART1_UART_Init();
+  MX_USART2_UART_Init();
+  MX_I2C2_Init();
+
+  SystemApp_Init();
+  /* USER CODE BEGIN 2 */
+
+  // Print the compilation time at startup
+  APP_LOG(TS_OFF, VLEVEL_M, "Example teros12, compiled on %s %s\r\n", __DATE__,
+          __TIME__);
+
+  /* Infinite loop */
+  /* USER CODE BEGIN WHILE */
+  while (1) {
+
+    char buffer[20];
+    Teros12_Data data = {};
+    SDI12Status status = SDI12_OK;
+    SDI12_Measure_TypeDef measurement_info;
+    status = SDI12GetMeasurment('0', &measurement_info, buffer, 1000);
+
+    APP_PRINTF("Status code: %d\r\n", status);
+
+    APP_PRINTF("%s\r\n", buffer);
+
+    double raw = 2600.0;
+    double vwc = 6.771e-10 * (raw * raw * raw) - 5.105e-6 * (raw * raw) + 1.302e-2 * raw - 10.848;
+    char print_buffer[50];
+    snprintf(print_buffer, sizeof(print_buffer), "vwc (hardcoded): %f\r\n", vwc);
+    APP_PRINTF("%s", print_buffer);
+
+    // Sleep
+    for (int i = 0; i <= 4000000; i++) {
+      asm("nop");
+    };
+    // HAL_Delay(DELAY);
+  }
+}
+
+/**
+ * @brief System Clock Configuration
+ * @retval None
+ */
+void SystemClock_Config(void) {
+  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+
+  /** Configure LSE Drive Capability
+   */
+  HAL_PWR_EnableBkUpAccess();
+  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
+
+  /** Configure the main internal regulator output voltage
+   */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /** Initializes the CPU, AHB and APB buses clocks
+   */
+  RCC_OscInitStruct.OscillatorType =
+      RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_MSI;
+  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV1;
+  RCC_OscInitStruct.PLL.PLLN = 42;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV4;
+  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+
+  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
+   */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3 | RCC_CLOCKTYPE_HCLK |
+                                RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 |
+                                RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV5;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK) {
+    Error_Handler();
+  }
+  HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1);
+}
+
+/* USER CODE BEGIN 4 */
+
+/* USER CODE END 4 */
+
+/**
+ * @brief  This function is executed in case of error occurrence.
+ * @retval None
+ */
+void Error_Handler(void) {
+  /* USER CODE BEGIN Error_Handler_Debug */
+  char error[30];
+  int error_len = sprintf(error, "Error!  HAL Status: %d\n", rc);
+  HAL_UART_Transmit(&huart1, (const uint8_t *)error, error_len, 1000);
+
+  /* User can add his own implementation to report the HAL error return state */
+  __disable_irq();
+  while (1) {
+  }
+  /* USER CODE END Error_Handler_Debug */
+}
+
+#ifdef USE_FULL_ASSERT
+/**
+ * @brief  Reports the name of the source file and the source line number
+ *         where the assert_param error has occurred.
+ * @param  file: pointer to the source file name
+ * @param  line: assert_param error line source number
+ * @retval None
+ */
+void assert_failed(uint8_t *file, uint32_t line) {
+  /* USER CODE BEGIN 6 */
+  /* User can add his own implementation to report the file name and line
+     number, ex: printf("Wrong parameters value: file %s on line %d\r\n", file,
+     line) */
+  /* USER CODE END 6 */
+}
+#endif /* USE_FULL_ASSERT */

--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -107,6 +107,9 @@ build_flags =
 [env:example_sdi12]
 build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/example_sdi12.c>
 
+[env:example_teros12]
+build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/example_teros12.c>
+
 [env:example_teros21]
 build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/example_teros21.c>
 
@@ -151,4 +154,4 @@ test_filter =
 include_dir = Inc
 src_dir = Src
 
-default_envs = stm32, example_adc, example_phytos, calibrate_adc, example_sdi12, example_userConfig, example_gui, example_bme280
+default_envs = stm32, example_adc, example_phytos, calibrate_adc, example_sdi12, example_teros12, example_userConfig, example_gui, example_bme280


### PR DESCRIPTION
**Name/Affiliation/Title**
John

**Purpose of the PR**
Add environment to print string of teros12 readings.

**Development Environment**
`Linux spruce 6.6.72-1-lts #1 SMP PREEMPT_DYNAMIC Fri, 17 Jan 2025 14:04:26 +0000 x86_64 GNU/Linux`
`2.2.3-???`
`PlatformIO Core, version 6.1.16`

**Test Procedure**
Connect teros12 to SDI12 port and load the `example_teros12` code.

**Additional Context**
I swear that the teros12 was already implemented. There's protobuf code already in the repo to support this. Possibly a previous bad merge?

**Task List**

- [ ] Update `CHANGELOG.md`
- [ ] Static code analysis passes
- [ ] All environments can be built
- [ ] All tests pass
- [ ] Clear documentation for new code
- [ ] Linting passes
- [ ] (If applicable) Version bump python library

**Relevant Issues**
N/A