### PR TITLE
Add support for teros12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ firmware versions for a hardware version.
 ### Added
 
 - WiFi upload method [#46](i46)
+- Support for the Teros12 sensor [#172](i172)
 
 ### Changed
 
 - Fixed issue with buffer addressing [#174](i174)
 
 [i46]: https://github.com/jlab-sensing/ENTS-node-firmware/issues/46
+[i172]: https://github.com/jlab-sensing/ENTS-node-firmware/issues/172
 [i174]: https://github.com/jlab-sensing/ENTS-node-firmware/issues/174
 
 ## [2.3.0] - 2025-02-26

--- a/proto/python/src/soil_power_sensor_protobuf/config/user_config.py
+++ b/proto/python/src/soil_power_sensor_protobuf/config/user_config.py
@@ -1,16 +1,16 @@
 """
 @brief PyQt5 GUI Application for Configuring User Settings
 
-This module provides a PyQt5-based graphical interface for configuring user settings. 
-The application allows users to input configuration details, including Logger ID, Cell ID, 
-Upload Method (WiFi or LoRa), Upload Interval, Enabled Sensors, and Calibration parameters 
-for voltage and current (V/I Slope and Offset). 
+This module provides a PyQt5-based graphical interface for configuring user settings.
+The application allows users to input configuration details, including Logger ID, Cell ID,
+Upload Method (WiFi or LoRa), Upload Interval, Enabled Sensors, and Calibration parameters
+for voltage and current (V/I Slope and Offset).
 
 Key features:
 - **Save and Load**: Users can save configurations to a file or load previous configurations for easy reuse.
-- **Real-time Configuration**: By pressing the "Send Configuration" button, the settings are serialized with Protobuf 
+- **Real-time Configuration**: By pressing the "Send Configuration" button, the settings are serialized with Protobuf
   and transmitted over UART to the STM32 for direct application.
-  
+
 @file user_config.py
 @author Ahmed Hassan Falah
 @date 2024-10-10

--- a/stm32/Src/examples/example_teros12.c
+++ b/stm32/Src/examples/example_teros12.c
@@ -1,0 +1,214 @@
+/**
+ * @brief Example teros12 code
+ * 
+ * Prints teros12 measurements over serial
+ *
+ * @author John Madden <jmadden173@pm.me>
+ * @date 2025-02-11
+ */
+
+#include "adc.h"
+#include "app_lorawan.h"
+#include "dma.h"
+#include "gpio.h"
+#include "i2c.h"
+#include "usart.h"
+
+/* Private includes ----------------------------------------------------------*/
+/* USER CODE BEGIN Includes */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sdi12.h"
+#include "sys_app.h"
+#include "teros21.h"
+
+/* USER CODE END Includes */
+
+/* Private typedef -----------------------------------------------------------*/
+/* USER CODE BEGIN PTD */
+
+/* USER CODE END PTD */
+
+/* Private define ------------------------------------------------------------*/
+/* USER CODE BEGIN PD */
+
+/* USER CODE END PD */
+
+/* Private macro -------------------------------------------------------------*/
+/* USER CODE BEGIN PM */
+
+/* USER CODE END PM */
+
+/* Private variables ---------------------------------------------------------*/
+
+/* USER CODE BEGIN PV */
+
+/* USER CODE END PV */
+
+/* Private function prototypes -----------------------------------------------*/
+void SystemClock_Config(void);
+/* USER CODE BEGIN PFP */
+/* USER CODE END PFP */
+
+/* Private user code ---------------------------------------------------------*/
+/* USER CODE BEGIN 0 */
+
+/* USER CODE END 0 */
+/**
+ * @brief  The application entry point.
+ * @retval int
+ */
+int main(void) {
+  /* USER CODE BEGIN 1 */
+
+  /* USER CODE END 1 */
+
+  /* MCU Configuration--------------------------------------------------------*/
+
+  /* Reset of all peripherals, Initializes the Flash interface and the Systick.
+   */
+  HAL_Init();
+
+  /* USER CODE BEGIN Init */
+  /* USER CODE END Init */
+
+  /* Configure the system clock */
+  SystemClock_Config();
+
+  /* USER CODE BEGIN SysInit */
+
+  /* USER CODE END SysInit */
+
+  /* Initialize all configured peripherals */
+  MX_GPIO_Init();
+  MX_DMA_Init();
+  MX_USART1_UART_Init();
+  MX_USART2_UART_Init();
+  MX_I2C2_Init();
+
+  SystemApp_Init();
+  /* USER CODE BEGIN 2 */
+
+  // Print the compilation time at startup
+  APP_LOG(TS_OFF, VLEVEL_M, "Example teros12, compiled on %s %s\r\n", __DATE__,
+          __TIME__);
+
+  /* Infinite loop */
+  /* USER CODE BEGIN WHILE */
+  while (1) {
+
+    char buffer[20];
+    Teros12_Data data = {};
+    SDI12Status status = SDI12_OK;
+    SDI12_Measure_TypeDef measurement_info;
+    status = SDI12GetMeasurment('0', &measurement_info, buffer, 1000);
+
+    APP_PRINTF("Status code: %d\r\n", status);
+
+    APP_PRINTF("%s\r\n", buffer);
+
+    double raw = 2600.0;
+    double vwc = 6.771e-10 * (raw * raw * raw) - 5.105e-6 * (raw * raw) + 1.302e-2 * raw - 10.848;
+    char print_buffer[50];
+    snprintf(print_buffer, sizeof(print_buffer), "vwc (hardcoded): %f\r\n", vwc);
+    APP_PRINTF("%s", print_buffer);
+
+    // Sleep
+    for (int i = 0; i <= 4000000; i++) {
+      asm("nop");
+    };
+    // HAL_Delay(DELAY);
+  }
+}
+
+/**
+ * @brief System Clock Configuration
+ * @retval None
+ */
+void SystemClock_Config(void) {
+  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+
+  /** Configure LSE Drive Capability
+   */
+  HAL_PWR_EnableBkUpAccess();
+  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
+
+  /** Configure the main internal regulator output voltage
+   */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /** Initializes the CPU, AHB and APB buses clocks
+   */
+  RCC_OscInitStruct.OscillatorType =
+      RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_MSI;
+  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV1;
+  RCC_OscInitStruct.PLL.PLLN = 42;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV4;
+  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+
+  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
+   */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3 | RCC_CLOCKTYPE_HCLK |
+                                RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 |
+                                RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV5;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK) {
+    Error_Handler();
+  }
+  HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1);
+}
+
+/* USER CODE BEGIN 4 */
+
+/* USER CODE END 4 */
+
+/**
+ * @brief  This function is executed in case of error occurrence.
+ * @retval None
+ */
+void Error_Handler(void) {
+  /* USER CODE BEGIN Error_Handler_Debug */
+  char error[30];
+  int error_len = sprintf(error, "Error!  HAL Status: %d\n", rc);
+  HAL_UART_Transmit(&huart1, (const uint8_t *)error, error_len, 1000);
+
+  /* User can add his own implementation to report the HAL error return state */
+  __disable_irq();
+  while (1) {
+  }
+  /* USER CODE END Error_Handler_Debug */
+}
+
+#ifdef USE_FULL_ASSERT
+/**
+ * @brief  Reports the name of the source file and the source line number
+ *         where the assert_param error has occurred.
+ * @param  file: pointer to the source file name
+ * @param  line: assert_param error line source number
+ * @retval None
+ */
+void assert_failed(uint8_t *file, uint32_t line) {
+  /* USER CODE BEGIN 6 */
+  /* User can add his own implementation to report the file name and line
+     number, ex: printf("Wrong parameters value: file %s on line %d\r\n", file,
+     line) */
+  /* USER CODE END 6 */
+}
+#endif /* USE_FULL_ASSERT */

--- a/stm32/Src/examples/example_teros12.c
+++ b/stm32/Src/examples/example_teros12.c
@@ -7,51 +7,19 @@
  * @date 2025-02-11
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "adc.h"
 #include "app_lorawan.h"
 #include "dma.h"
 #include "gpio.h"
 #include "i2c.h"
-#include "usart.h"
-
-/* Private includes ----------------------------------------------------------*/
-/* USER CODE BEGIN Includes */
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "sys_app.h"
 #include "teros12.h"
+#include "usart.h"
 
-/* USER CODE END Includes */
-
-/* Private typedef -----------------------------------------------------------*/
-/* USER CODE BEGIN PTD */
-
-/* USER CODE END PTD */
-
-/* Private define ------------------------------------------------------------*/
-/* USER CODE BEGIN PD */
-
-/* USER CODE END PD */
-
-/* Private macro -------------------------------------------------------------*/
-/* USER CODE BEGIN PM */
-
-/* USER CODE END PM */
-
-/* Private variables ---------------------------------------------------------*/
-
-/* USER CODE BEGIN PV */
-
-/* USER CODE END PV */
-
-/* Private function prototypes -----------------------------------------------*/
 void SystemClock_Config(void);
-/* USER CODE BEGIN PFP */
-/* USER CODE END PFP */
-
-/* Private user code ---------------------------------------------------------*/
-/* USER CODE BEGIN 0 */
 
 /* USER CODE END 0 */
 /**
@@ -59,25 +27,10 @@ void SystemClock_Config(void);
  * @retval int
  */
 int main(void) {
-  /* USER CODE BEGIN 1 */
-
-  /* USER CODE END 1 */
-
-  /* MCU Configuration--------------------------------------------------------*/
-
-  /* Reset of all peripherals, Initializes the Flash interface and the Systick.
-   */
   HAL_Init();
-
-  /* USER CODE BEGIN Init */
-  /* USER CODE END Init */
 
   /* Configure the system clock */
   SystemClock_Config();
-
-  /* USER CODE BEGIN SysInit */
-
-  /* USER CODE END SysInit */
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
@@ -87,13 +40,11 @@ int main(void) {
   MX_I2C2_Init();
 
   SystemApp_Init();
-  /* USER CODE BEGIN 2 */
 
   // Print the compilation time at startup
   APP_LOG(TS_OFF, VLEVEL_M, "Example teros12, compiled on %s %s\r\n", __DATE__,
           __TIME__);
 
-  /* Infinite loop */
   /* USER CODE BEGIN WHILE */
   while (1) {
     Teros12Data data = {};
@@ -111,7 +62,7 @@ int main(void) {
     // Sleep
     for (int i = 0; i <= 4000000; i++) {
       asm("nop");
-    };
+    }
   }
 }
 
@@ -179,7 +130,8 @@ void SystemClock_Config(void) {
 void Error_Handler(void) {
   /* USER CODE BEGIN Error_Handler_Debug */
   char error[30];
-  int error_len = sprintf(error, "Error!  HAL Status: %d\n", rc);
+  int error_len =
+      snprintf(error, sizeof(error), "Error!  HAL Status: %d\n", rc);
   HAL_UART_Transmit(&huart1, (const uint8_t *)error, error_len, 1000);
 
   /* User can add his own implementation to report the HAL error return state */

--- a/stm32/Src/examples/example_teros12.c
+++ b/stm32/Src/examples/example_teros12.c
@@ -1,6 +1,6 @@
 /**
  * @brief Example teros12 code
- * 
+ *
  * Prints teros12 measurements over serial
  *
  * @author John Madden <jmadden173@pm.me>
@@ -96,7 +96,6 @@ int main(void) {
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
   while (1) {
-
     Teros12Data data = {};
     SDI12Status status = SDI12_OK;
     status = Teros12GetMeasurement('0', &data);
@@ -104,8 +103,8 @@ int main(void) {
     char print_buffer[256];
 
     snprintf(print_buffer, sizeof(print_buffer),
-             "Status code: %d; addr = %c; vwc: %f; temp: %f; ec: %d",
-             status, data.addr, data.vwc, data.temp, data.ec);
+             "Status code: %d; addr = %c; vwc: %f; temp: %f; ec: %d", status,
+             data.addr, data.vwc, data.temp, data.ec);
 
     APP_PRINTF("%s\r\n", print_buffer);
 

--- a/stm32/Src/examples/example_teros12.c
+++ b/stm32/Src/examples/example_teros12.c
@@ -19,9 +19,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "sdi12.h"
 #include "sys_app.h"
-#include "teros21.h"
+#include "teros12.h"
 
 /* USER CODE END Includes */
 
@@ -98,27 +97,22 @@ int main(void) {
   /* USER CODE BEGIN WHILE */
   while (1) {
 
-    char buffer[20];
-    Teros12_Data data = {};
+    Teros12Data data = {};
     SDI12Status status = SDI12_OK;
-    SDI12_Measure_TypeDef measurement_info;
-    status = SDI12GetMeasurment('0', &measurement_info, buffer, 1000);
+    status = Teros12GetMeasurement('0', &data);
 
-    APP_PRINTF("Status code: %d\r\n", status);
+    char print_buffer[256];
 
-    APP_PRINTF("%s\r\n", buffer);
+    snprintf(print_buffer, sizeof(print_buffer),
+             "Status code: %d; addr = %c; vwc: %f; temp: %f; ec: %d",
+             status, data.addr, data.vwc, data.temp, data.ec);
 
-    double raw = 2600.0;
-    double vwc = 6.771e-10 * (raw * raw * raw) - 5.105e-6 * (raw * raw) + 1.302e-2 * raw - 10.848;
-    char print_buffer[50];
-    snprintf(print_buffer, sizeof(print_buffer), "vwc (hardcoded): %f\r\n", vwc);
-    APP_PRINTF("%s", print_buffer);
+    APP_PRINTF("%s\r\n", print_buffer);
 
     // Sleep
     for (int i = 0; i <= 4000000; i++) {
       asm("nop");
     };
-    // HAL_Delay(DELAY);
   }
 }
 
@@ -207,7 +201,7 @@ void Error_Handler(void) {
 void assert_failed(uint8_t *file, uint32_t line) {
   /* USER CODE BEGIN 6 */
   /* User can add his own implementation to report the file name and line
-     number, ex: printf("Wrong parameters value: file %s on line %d\r\n", file,
+     number, ex printf("Wrong parameters value: file %s on line %d\r\n", file,
      line) */
   /* USER CODE END 6 */
 }

--- a/stm32/Src/main.c
+++ b/stm32/Src/main.c
@@ -35,7 +35,6 @@
 #include <stdbool.h>
 
 #include "ads.h"
-#include "sdi12.h"
 #include "phytos31.h"
 #include "bme280_sensor.h"
 #include "rtc.h"
@@ -44,6 +43,7 @@
 #include "controller/controller.h"
 #include "controller/wifi.h"
 #include "userConfig.h"
+#include "teros12.h"
 #include "teros21.h"
 /* USER CODE END Includes */
 
@@ -130,12 +130,8 @@ int main(void)
   UserConfigPrint();
 
   // required for SDI-12
-  //MX_USART2_UART_Init();
-  //MX_TIM1_Init();
-  /* USER CODE BEGIN 2 */
-
-  // init external adc
-  //MX_RTC_Init();
+  MX_USART2_UART_Init();
+  MX_TIM1_Init();
 
   // initialize the user config interrupt
   UserConfig_InitAdvanceTrace();
@@ -176,8 +172,8 @@ int main(void)
       APP_LOG(TS_OFF, VLEVEL_M, "ADS Enabled!\n");
     }
     if (sensor == EnabledSensor_Teros12) {
-      APP_LOG(TS_OFF, VLEVEL_M, "Teros12 not implemented!\n");
-      //SensorsAdd(SDI12_Teros12Measure);
+      APP_LOG(TS_OFF, VLEVEL_M, "Teros12 Enabled!\n");
+      SensorsAdd(Teros12Measure);
     }
     if (sensor == EnabledSensor_BME280) {
       BME280Init();

--- a/stm32/lib/sdi12/include/sdi12.h
+++ b/stm32/lib/sdi12/include/sdi12.h
@@ -41,15 +41,6 @@ typedef struct {
   uint8_t NumValues;
 } SDI12_Measure_TypeDef;
 
-/* The relevant data for a TEROS-12 sensor*/
-typedef struct {
-  int ec;
-  float vwc_raw;
-  float vwc_adj;
-  float tmp;
-  int addr;
-} Teros12_Data;
-
 /**
 ******************************************************************************
 * @brief    Wake all sensors on the data line.

--- a/stm32/lib/sdi12/include/teros12.h
+++ b/stm32/lib/sdi12/include/teros12.h
@@ -1,3 +1,10 @@
+/**
+ * @file teros12.h
+ * @author John Madden <jmadden173@pm.me>
+ * @brief Drives for reading measurements from Teros12 sensor
+ * @date 2025-03-05
+ */
+
 #ifndef LIB_SDI12_INCLUDE_TEROS12_H_
 #define LIB_SDI12_INCLUDE_TEROS12_H_
 

--- a/stm32/lib/sdi12/include/teros12.h
+++ b/stm32/lib/sdi12/include/teros12.h
@@ -1,0 +1,57 @@
+#ifndef LIB_SDI12_INCLUDE_TEROS12_H_
+#define LIB_SDI12_INCLUDE_TEROS12_H_
+
+#include <sdi12.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  char addr;
+  float vwc;
+  float temp;
+  unsigned int ec;
+} Teros12Data;
+
+/**
+ * @brief Parse measurement string from Teros21 sensor
+ *
+ * The buffer is expected to be the following format. [+-] can either be a + or
+ * - sign.:
+ * a+<calibratedCountsVWC>[+-]<temperature>+<electricalConductivity>
+ *
+ * Example real world values:
+ * 0+1846.16+22.3+1
+ *
+ * @param buffer Raw measurement string 
+ * @param data Pointer to the data structure to store the measurement
+ * @return SDI12Status
+ */
+SDI12Status Teros12ParseMeasurement(const char *buffer, Teros12Data *data);
+
+/**
+ * @brief Read and parse a Teros12 measurement
+ *
+ * @param addr Address of the sensor
+ * @param data Pointer to the data structure to store the measurement
+ * @return SDI12Status
+ */
+SDI12Status Teros12GetMeasurement(char addr, Teros12Data *data);
+
+/**
+ * @brief Get measurement from Teros12 sensor
+ *
+ * Measures a Teros12 at address 0 and encodes it into a serialized
+ * measurement.
+ *
+ * @param data Buffer to store measurement
+ * @return Length of measurement
+ *
+ * @see SensorsPrototypeMeasure
+ *
+ */
+size_t Teros12Measure(uint8_t *data);
+
+
+#endif  // LIB_SDI12_INCLUDE_TEROS12_H_

--- a/stm32/lib/sdi12/include/teros12.h
+++ b/stm32/lib/sdi12/include/teros12.h
@@ -24,7 +24,7 @@ typedef struct {
  * Example real world values:
  * 0+1846.16+22.3+1
  *
- * @param buffer Raw measurement string 
+ * @param buffer Raw measurement string
  * @param data Pointer to the data structure to store the measurement
  * @return SDI12Status
  */
@@ -52,6 +52,5 @@ SDI12Status Teros12GetMeasurement(char addr, Teros12Data *data);
  *
  */
 size_t Teros12Measure(uint8_t *data);
-
 
 #endif  // LIB_SDI12_INCLUDE_TEROS12_H_

--- a/stm32/lib/sdi12/include/teros21.h
+++ b/stm32/lib/sdi12/include/teros21.h
@@ -1,3 +1,10 @@
+/**
+ * @file teros21.h
+ * @author John Madden <jmadden173@pm.me>
+ * @brief Drives for reading measurements from Teros21 sensor
+ * @date 2025-03-05
+ */
+
 #ifndef LIB_SDI12_INCLUDE_TEROS21_H_
 #define LIB_SDI12_INCLUDE_TEROS21_H_
 

--- a/stm32/lib/sdi12/src/teros12.c
+++ b/stm32/lib/sdi12/src/teros12.c
@@ -1,0 +1,66 @@
+#include "teros12.h"
+
+#include "stm32_systime.h"
+#include "userConfig.h"
+
+SDI12Status Teros12ParseMeasurement(const char *buffer, Teros12Data *data) {
+  // parse string and check number of characters parsed
+  int rc = sscanf(buffer, "%1c+%f%f+%d", &data->addr, &data->vwc, &data->temp, &data->ec);
+  if (rc < 4) {
+    return SDI12_PARSING_ERROR;
+  }
+
+  return SDI12_OK;
+}
+
+SDI12Status Teros12GetMeasurement(char addr, Teros12Data *data) {
+  // buffer to store measurement
+  // based on the measurement range of the device the max string length is 
+  // 0+1846.16+22.3+20000 = 20
+  char buffer[20];
+
+  // status messages
+  SDI12Status status = SDI12_OK;
+
+  // get measurement string
+  // Measured 130ms experimentally, set to 200 ms to be safe
+  SDI12_Measure_TypeDef measurment_info;
+  status = SDI12GetMeasurment((uint8_t)addr, &measurment_info, buffer, 1000);
+  if (status != SDI12_OK) {
+    return status;
+  }
+
+  // parse measurement into data structure
+  size_t buffer_len = 5;
+  status = Teros12ParseMeasurement(buffer, data);
+  if (status != SDI12_OK) {
+    return status;
+  }
+
+  return status;
+
+}
+
+size_t Teros12Measure(uint8_t *data) {
+  // get timestamp
+  SysTime_t ts = SysTimeGet();
+
+  Teros12Data sens_data = {};
+  SDI12Status status = Teros12GetMeasurement('0', &sens_data);
+  if (status != SDI12_OK) {
+    return -1;
+  }
+
+  const UserConfiguration *cfg = UserConfigGet();
+
+  // calibration equation for mineral soils from Teros12 user manual
+  // https://publications.metergroup.com/Manuals/20587_TEROS11-12_Manual_Web.pdf?_gl=1*174xdyp*_gcl_au*MTIxODkwMzcuMTc0MTIwMjU3Nw..
+  float vwc_adj = (3.879e-4 * sens_data.vwc) - 0.6956;
+
+  size_t data_len =
+      EncodeTeros12Measurement(ts.Seconds, cfg->logger_id, cfg->cell_id,
+                               sens_data.vwc, vwc_adj, sens_data.temp, sens_data.ec, data);
+
+  return data_len;
+
+}

--- a/stm32/lib/sdi12/src/teros12.c
+++ b/stm32/lib/sdi12/src/teros12.c
@@ -5,7 +5,8 @@
 
 SDI12Status Teros12ParseMeasurement(const char *buffer, Teros12Data *data) {
   // parse string and check number of characters parsed
-  int rc = sscanf(buffer, "%1c+%f%f+%d", &data->addr, &data->vwc, &data->temp, &data->ec);
+  int rc = sscanf(buffer, "%1c+%f%f+%d", &data->addr, &data->vwc, &data->temp,
+                  &data->ec);
   if (rc < 4) {
     return SDI12_PARSING_ERROR;
   }
@@ -15,7 +16,7 @@ SDI12Status Teros12ParseMeasurement(const char *buffer, Teros12Data *data) {
 
 SDI12Status Teros12GetMeasurement(char addr, Teros12Data *data) {
   // buffer to store measurement
-  // based on the measurement range of the device the max string length is 
+  // based on the measurement range of the device the max string length is
   // 0+1846.16+22.3+20000 = 20
   char buffer[20];
 
@@ -38,7 +39,6 @@ SDI12Status Teros12GetMeasurement(char addr, Teros12Data *data) {
   }
 
   return status;
-
 }
 
 size_t Teros12Measure(uint8_t *data) {
@@ -57,10 +57,9 @@ size_t Teros12Measure(uint8_t *data) {
   // https://publications.metergroup.com/Manuals/20587_TEROS11-12_Manual_Web.pdf?_gl=1*174xdyp*_gcl_au*MTIxODkwMzcuMTc0MTIwMjU3Nw..
   float vwc_adj = (3.879e-4 * sens_data.vwc) - 0.6956;
 
-  size_t data_len =
-      EncodeTeros12Measurement(ts.Seconds, cfg->logger_id, cfg->cell_id,
-                               sens_data.vwc, vwc_adj, sens_data.temp, sens_data.ec, data);
+  size_t data_len = EncodeTeros12Measurement(
+      ts.Seconds, cfg->logger_id, cfg->cell_id, sens_data.vwc, vwc_adj,
+      sens_data.temp, sens_data.ec, data);
 
   return data_len;
-
 }

--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -116,6 +116,9 @@ build_flags =
 [env:example_sdi12]
 build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/example_sdi12.c>
 
+[env:example_teros12]
+build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/example_teros12.c>
+
 [env:example_teros21]
 build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/example_teros21.c>
 
@@ -160,4 +163,4 @@ test_filter =
 include_dir = Inc
 src_dir = Src
 
-default_envs = stm32, example_adc, example_phytos, calibrate_adc, example_sdi12, example_userConfig, example_gui, example_bme280
+default_envs = stm32, example_adc, example_phytos, calibrate_adc, example_sdi12, example_teros12, example_userConfig, example_gui, example_bme280


### PR DESCRIPTION
**Name/Affiliation/Title**
John, UCSC, Maintainer

**Purpose of the PR**
Add back the ability to read measurements from teros12 and upload them to Dirtviz

**Development Environment**
Checked on the following environment:
OS: `Linux spruce 6.12.16-1-lts #1 SMP PREEMPT_DYNAMIC Fri, 21 Feb 2025 19:20:31 +0000 x86_64 GNU/Linux`
PlatformIO Core, version `6.1.16`
Python `3.13.2`
Hardware: `2.2.3-040`

**Test Procedure**
1. Flash both esp32 and stm32
2. Use gui to enable the teros12
3. Goto dirtviz to view data

**Additional Context**
PR #171 should be closed as it was merged into this branch.

**Task List**

- [x] Update `CHANGELOG.md`
- [x] Static code analysis passes
- [x] All environments can be built
- [x] All tests pass
- [x] Clear documentation for new code
- [x] Linting passes
- [ ] (If applicable) Version bump python library

**Relevant Issues**
Closes #172 