### PR TITLE
Hotfix/teros12 parse error

### DIFF
--- a/stm32/Src/examples/example_sdi12.c
+++ b/stm32/Src/examples/example_sdi12.c
@@ -50,23 +50,11 @@ int main(void) {
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
+  MX_DMA_Init();
   MX_USART1_UART_Init();
   MX_USART2_UART_Init();
-  // __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
-  // Add this back when the rtc is integrated.
-  // Hopefully this will fix the issue.
-  // Then you can remove the nops in SDI12_WakeSensors
-  // MX_RTC_Init();
 
-  /* Ensure that MSI is wake-up system clock */
-  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
-
-  /*Initialize timer and RTC*/
-  UTIL_TIMER_Init();
-
-  // HAL_TIM_OnePulse_MspInit(&htim1);
-  // __HAL_RCC_TIM1_CLK_ENABLE();
-  // HAL_TIM_OnePulse_Init(&htim1, TIM_OPMODE_SINGLE);
+  SystemApp_Init();
 
   // User level initialization
 

--- a/stm32/lib/sdi12/src/sdi12.c
+++ b/stm32/lib/sdi12/src/sdi12.c
@@ -20,7 +20,7 @@
 
 static const uint16_t REQUEST_MEASURMENT_RESPONSE_SIZE = 7;
 static const uint16_t SERVICE_REQUEST_SIZE = 3;
-static const uint16_t MEASURMENT_DATA_SIZE = 18;
+static const uint16_t MEASURMENT_DATA_SIZE = 30;
 static const uint16_t SEND_COMMAND_TIMEOUT = 1000;
 
 /* Helper function to parse the sensor's response to a get measurment command*/


### PR DESCRIPTION
**Name/Affiliation/Title**
John 

**Purpose of the PR**
Fix teros12 parsing measurement

**Development Environment**
OS: `Linux spruce 6.12.16-1-lts #1 SMP PREEMPT_DYNAMIC Fri, 21 Feb 2025 19:20:31 +0000 x86_64 GNU/Linux`
PlatformIO Core, version `6.1.16`
Python `3.13.2`
Hardware: `2.2.3-021`

**Test Procedure**
Run `example_teros12` and try uploading terso12 with measurements.

**Additional Context**
Add any other context or screenshots about the pull request here.

**Task List**

- [ ] Update `CHANGELOG.md`
- [ ] Static code analysis passes
- [ ] All environments can be built
- [ ] All tests pass
- [ ] Clear documentation for new code
- [ ] Linting passes
- [ ] (If applicable) Version bump python library

**Relevant Issues**
Link issues that the PR is related. If the PR resolves the issue using *Closes* keyword to automatically close the issue after successful merge.