### PR TITLE
Added loading of user config

### DIFF
--- a/stm32/Src/examples/example_adc.c
+++ b/stm32/Src/examples/example_adc.c
@@ -101,6 +101,9 @@ int main(void) {
   // init systemapp
   SystemApp_Init();
 
+
+  UserConfigLoad();
+
   /*Initialize timer and RTC*/
   /*Have to be initilized in example files because LoRaWan cannot be initialized
    * like in main*/


### PR DESCRIPTION
When running `example_adc` the output was all zeros since the default user config loaded 0's for the calibration. Added loading of user config.