### PR TITLE
Print `git rev-parse` over serial

### DIFF
--- a/esp32/git_rev_macro.py
+++ b/esp32/git_rev_macro.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import subprocess
+
+revision = (
+    subprocess.check_output(["git", "rev-parse", "HEAD"])
+    .strip()
+    .decode("utf-8")
+)
+print("'-DGIT_REV=\"%s\"'" % revision)

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -14,6 +14,12 @@ board = esp32-c3-devkitm-1
 framework = arduino
 build_src_filter = +<*> -<.git/> -<examples/*>
 
+# !python git_rev_macro.py
+# adds the git revision macro as a define
+
+build_flags =
+    !python git_rev_macro.py
+
 lib_deps =
   Wire
   WiFi

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -60,6 +60,7 @@ RESET!
 
   Log.noticeln("ents-node esp32 firmware, compiled at %s %s", __DATE__,
                __TIME__);
+  Log.noticeln("Git SHA: %s", GIT_REV);
 
   Log.noticeln("Starting i2c interface...");
 

--- a/stm32/Src/main.c
+++ b/stm32/Src/main.c
@@ -144,6 +144,7 @@ int main(void)
 
   // Debug message, gets printed after init code
   APP_PRINTF("Soil Power Sensor Wio-E5 firmware, compiled on %s %s\n", __DATE__, __TIME__);
+  APP_PRINTF("Git SHA: %s\n", GIT_REV);
 
   // configure sensors
   //SensorsAdd(SensorsMeasureTest);

--- a/stm32/git_rev_macro.py
+++ b/stm32/git_rev_macro.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import subprocess
+
+revision = (
+    subprocess.check_output(["git", "rev-parse", "HEAD"])
+    .strip()
+    .decode("utf-8")
+)
+print("'-DGIT_REV=\"%s\"'" % revision)

--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -42,6 +42,9 @@ platform_packages =
 # add the following flag for object files
 #-save-temps=obj
 
+# !python git_rev_macro.py
+# adds the git revision macro as a define
+
 build_flags = 
     -DDMA_CCR_SECM
     -DDMA_CCR_PRIV
@@ -51,6 +54,7 @@ build_flags =
     -DUSE_BSP_DRIVER
     -DFRAM_MB85RC1MT
     -DBME280_32BIT_ENABLE
+    !python git_rev_macro.py
 
 debug_build_flags = 
     -O1


### PR DESCRIPTION
Can help with identifying older versions of the firmware. Should be cross platform according to [this](https://docs.platformio.org/en/latest/projectconf/sections/env/options/build/build_flags.html)

Example from stm32.
```
...
API Port: 0
Soil Power Sensor Wio-E5 firmware, compiled on Apr  9 2025 12:50:29
Git SHA: 83446351495c9e35009e737ce0e6c3641b16d825
Teros12 Enabled!
...
```

Example from esp32
```
...
I: ents-node esp32 firmware, compiled at Apr  9 2025 12:53:15
I: Git SHA: eee0938475f882d0471a0d6162e1b525d065e266
...
```