### PR TITLE
WiFi upload until buffer is empty

### DIFF
--- a/stm32/Src/wifi.c
+++ b/stm32/Src/wifi.c
@@ -17,11 +17,6 @@
  */
 static UTIL_TIMER_Object_t UploadTimer = {};
 
-/**
- * @brief Period between uploads
- * 
- */
-static UTIL_TIMER_Time_t UploadPeriod = 10000;
 
 /**
  * @brief Function call for upload event
@@ -129,6 +124,12 @@ void Upload(void) {
     Connect();
   }
 
+  if (FramBufferLen() > 0) {
+    APP_LOG(TS_ON, VLEVEL_M, "Buffer not empty, starting another upload\r\n");
+    UploadEvent(NULL);
+  }
+
+
   StatusLedOff();
 }
 
@@ -137,6 +138,10 @@ void StartUploads(void) {
   APP_LOG(TS_ON, VLEVEL_M, "Starting sensor measurements...\t");
   SensorsStart();
   APP_LOG(TS_OFF, VLEVEL_M, "Started!\r\n");
+
+  // get upload period from user config
+  const UserConfiguration* cfg = UserConfigGet();
+  UTIL_TIMER_Time_t UploadPeriod = cfg->Upload_interval * 1000; 
 
   // setup upload task
   APP_LOG(TS_ON, VLEVEL_M, "Starting upload task...\t")

--- a/stm32/lib/sensors/src/sensors.c
+++ b/stm32/lib/sensors/src/sensors.c
@@ -44,7 +44,7 @@ static const uint8_t kBufferSize = LORAWAN_APP_DATA_BUFFER_MAX_SIZE;
 /** Periodic timer for querying sensors */
 static UTIL_TIMER_Object_t MeasureTimer;
 
-static uint32_t measure_period = MEASUREMENT_PERIOD;
+static uint32_t measure_period = 0;
 
 /**
  * @brief Measures sensors and adds to tx buffer

--- a/stm32/lib/storage/include/fram.h
+++ b/stm32/lib/storage/include/fram.h
@@ -92,32 +92,6 @@ FramStatus FramRead(FramAddr addr, size_t len, uint8_t *data);
  */
 FramAddr FramSize(void);
 
-/**
- * @brief Get number of pages
- *
- * A page is defined as a space of memory requiring the change of address.
- *
- * @return Number of pages
- */
-unsigned int FramPages(void);
-
-/**
- * @brief Gets the size of a segment
- *
- * @return Number of bytes in each segment
- */
-unsigned int FramSegmentSize(void);
-
-/**
- * @brief This function reads the user configurable settings from
- * non-volatile memory.
- *
- * @return configuration, an instance of the typedef struct
- * user_configurations.  Containing all the user defined settings to be
- * stored in non-volatile memory.
- */
-configuration ReadSettings(void);
-
 //
 /**
  * @brief This function reads the entirety of non-volatile memory and


### PR DESCRIPTION
**Name/Affiliation/Title**
John

**Purpose of the PR**
Change the upload logic when on WiFi to schedule upload events until the measurement buffer is empty.

**Development Environment**
OS: `Linux spruce 6.12.16-1-lts #1 SMP PREEMPT_DYNAMIC Fri, 21 Feb 2025 19:20:31 +0000 x86_64 GNU/Linux`
PlatformIO Core, version `6.1.16`
Python `3.13.2`
Hardware: `2.2.3-021`

**Test Procedure**
Configure board to upload via WiFi with more than one sensor connected. Should see a log message indicating the functionality
```
1746216220s282:Buffer: ac8c8110c81189ccad4c062ab8a29a610ed1118a1ab3
1746216220s385:Payload[34]: a c 8 c8 1 10 c8 1 18 9c ca d4 c0 6 12 12 11 ca 18 61 82 1 3c 38 c0 19 39 1d 2f 41 8d 8d fc 3e 
1746216220s388:Uploading data...	200
1746216220s519:Buffer not empty, starting another upload
1746216220s527:Payload[27]: a c 8 c8 1 10 c8 1 18 9c ca d4 c0 6 2a b 8 a2 9a 6 10 ed 11 18 a1 ab 3 
1746216220s530:Uploading data...	200
```

**Additional Context**
Add any other context or screenshots about the pull request here.

**Task List**

- [ ] Update `CHANGELOG.md`
- [ ] Static code analysis passes
- [ ] All environments can be built
- [ ] All tests pass
- [ ] Clear documentation for new code
- [ ] Linting passes
- [ ] (If applicable) Version bump python library

**Relevant Issues**
Closes #220 