### PR TITLE
Fix decoded protobuf dict missing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 minor versions follow hardware versioning with patches used to iterate on
 firmware versions for a hardware version.
 
+## [Unreleased]
+
+- Fixed missing fields when decoding messages [#243](i243)
+
+[i243]: https://github.com/jlab-sensing/ENTS-node-firmware/issues/243
+
 ## [2.3.2] - 2025-05-23
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  'protobuf>5.0.0',
+  'protobuf==6.31.1',
   'matplotlib',
   'pandas',
   'pyserial',

--- a/python/src/ents/calibrate/requirements.txt
+++ b/python/src/ents/calibrate/requirements.txt
@@ -1,9 +1,0 @@
-matplotlib
-pandas
-pyserial
-tqdm
-scikit-learn
-rocketlogger
-pyyaml
-ents
-protobuf==4.25.5

--- a/python/src/ents/proto/decode.py
+++ b/python/src/ents/proto/decode.py
@@ -57,8 +57,9 @@ def decode_measurement(data: bytes, raw: bool = True) -> dict:
     if not meas.HasField("measurement"):
         raise KeyError("Measurement missing data")
     measurement_type = meas.WhichOneof("measurement")
-    measurement_dict = MessageToDict(getattr(meas, measurement_type),
-                                     always_print_fields_with_no_presence=True)
+    measurement_dict = MessageToDict(
+        getattr(meas, measurement_type), always_print_fields_with_no_presence=True
+    )
 
     # store measurement type
     meta_dict["type"] = measurement_type

--- a/python/src/ents/proto/decode.py
+++ b/python/src/ents/proto/decode.py
@@ -51,13 +51,14 @@ def decode_measurement(data: bytes, raw: bool = True) -> dict:
     # convert meta into dict
     if not meas.HasField("meta"):
         raise KeyError("Measurement missing metadata")
-    meta_dict = MessageToDict(meas.meta)
+    meta_dict = MessageToDict(meas.meta, always_print_fields_with_no_presence=True)
 
     # decode measurement
     if not meas.HasField("measurement"):
         raise KeyError("Measurement missing data")
     measurement_type = meas.WhichOneof("measurement")
-    measurement_dict = MessageToDict(getattr(meas, measurement_type))
+    measurement_dict = MessageToDict(getattr(meas, measurement_type),
+                                     always_print_fields_with_no_presence=True)
 
     # store measurement type
     meta_dict["type"] = measurement_type

--- a/python/tests/test_generic.py
+++ b/python/tests/test_generic.py
@@ -120,8 +120,8 @@ class TestDecode(unittest.TestCase):
         self.assertEqual(123, meas_dict["data"]["ec"])
         self.assertEqual(int, meas_dict["data_type"]["ec"])
 
-    def test_phytos31(self):
-        """Test decoding of Phytos31 measurement"""
+    def test_bme280(self):
+        """Test decoding of bme280 measurement"""
 
         meas = Measurement()
         meas.meta.CopyFrom(self.meta)

--- a/python/tests/test_generic.py
+++ b/python/tests/test_generic.py
@@ -208,6 +208,26 @@ class TestDecode(unittest.TestCase):
         with self.assertRaises(KeyError):
             decode_measurement(data=meas_str)
 
+    def test_missing_default_values(self):
+        """Test to ensure that default valued fields are included in the
+        decoded dictionary
+        """
+
+        meas = Measurement()
+        meas.meta.CopyFrom(self.meta)
+
+        meas.teros12.vwc_raw = 2141.52
+        meas.teros12.vwc_adj = 0.45
+        meas.teros12.temp = 25.0
+
+        # set integer to default value of 0
+        meas.teros12.ec = 0
+
+        meas_str = meas.SerializeToString()
+
+        meas_dict = decode_measurement(data=meas_str)
+
+        self.assertIn("ec", meas_dict["data"])
 
 class TestEsp32(unittest.TestCase):
     def test_cmd_not_implemented(self):

--- a/python/tests/test_generic.py
+++ b/python/tests/test_generic.py
@@ -229,6 +229,7 @@ class TestDecode(unittest.TestCase):
 
         self.assertIn("ec", meas_dict["data"])
 
+
 class TestEsp32(unittest.TestCase):
     def test_cmd_not_implemented(self):
         """Checks that an exception is raised when a non-existing command is


### PR DESCRIPTION
**Name/Affiliation/Title**
John Madden, UCSC, maintainer

**Purpose of the PR**
- Resolve #243 
- Add unit tests to check for same issue in future implementation
- Pin protobuf at the most recent version to prevent undefined behavior from upstream changes.

**Development Environment**
```
OS: `Linux spruce 6.12.16-1-lts #1 SMP PREEMPT_DYNAMIC Fri, 21 Feb 2025 19:20:31 +0000 x86_64 GNU/Linux`
PlatformIO Core, version `6.1.16`
Python `3.13.2`
Hardware: `2.2.3-021`
```

**Test Procedure**
Run the python tests or check actions

**Additional Context**
Add any other context or screenshots about the pull request here.

**Task List**

- [x] Update `CHANGELOG.md`
- [x] Static code analysis passes
- [x] All environments can be built
- [ ] All tests pass
- [x] Clear documentation for new code
- [x] Linting passes
- [ ] (If applicable) Version bump python library

**Relevant Issues**
Closes #243 