### PR TITLE
Instant upload for WiFi

### DIFF
--- a/stm32/Inc/utilities_def.h
+++ b/stm32/Inc/utilities_def.h
@@ -64,7 +64,7 @@ typedef enum
 {
   CFG_SEQ_Prio_0,
   /* USER CODE BEGIN CFG_SEQ_Prio_Id_t */
-
+  CFG_SEQ_Prio_1,
   /* USER CODE END CFG_SEQ_Prio_Id_t */
   CFG_SEQ_Prio_NBR,
 } CFG_SEQ_Prio_Id_t;

--- a/stm32/Src/wifi.c
+++ b/stm32/Src/wifi.c
@@ -260,20 +260,20 @@ bool Connect(void) {
     if (status == CONTROLLER_WIFI_CONNECTED) {
       break;
     } else {
-      if (status == CONTROLLER_WIFI_DISCONNECTED) {
-        continue;
-      } else if (status == CONTROLLER_WIFI_NO_SSID_AVAIL) {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error! No SSID available!\r\n");
-        return false;
-      } else if (status == CONTROLLER_WIFI_CONNECT_FAILED) {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error! Connect failed!\r\n");
-        return false;
-      }
-
       if (retries >= max_retries) {
         APP_LOG(TS_OFF, VLEVEL_M, "Error! Timeout after %d retries!\r\n",
                 retries);
         return false;
+      } else {
+        if (status == CONTROLLER_WIFI_DISCONNECTED) {
+          continue;
+        } else if (status == CONTROLLER_WIFI_NO_SSID_AVAIL) {
+          APP_LOG(TS_OFF, VLEVEL_M, "Error! No SSID available!\r\n");
+          return false;
+        } else if (status == CONTROLLER_WIFI_CONNECT_FAILED) {
+          APP_LOG(TS_OFF, VLEVEL_M, "Error! Connect failed!\r\n");
+          return false;
+        }
       }
     }
   }

--- a/stm32/Src/wifi.c
+++ b/stm32/Src/wifi.c
@@ -2,18 +2,18 @@
 
 #include <stm32_systime.h>
 
-#include "sys_app.h"
+#include "controller/wifi.h"
+#include "fifo.h"
 #include "sensors.h"
+#include "status_led.h"
 #include "stm32_seq.h"
 #include "stm32_timer.h"
-#include "fifo.h"
-#include "controller/wifi.h"
+#include "sys_app.h"
 #include "userConfig.h"
-#include "status_led.h"
 
 /**
  * @brief Timer for uploads
- * 
+ *
  */
 static UTIL_TIMER_Object_t UploadTimer = {};
 
@@ -27,17 +27,16 @@ const unsigned int max_retries = 5;
  */
 const unsigned int retry_delay = 1000;
 
-
 /**
  * @brief Function call for upload event
- * 
+ *
  * @param context Timer context.
  */
-void UploadEvent(void *context);
+void UploadEvent(void* context);
 
 /**
  * @brief Upload data to hub
- * 
+ *
  * Posts data to configured url.
  */
 void Upload(void);
@@ -60,7 +59,7 @@ bool Disconnect(void);
 
 /**
  * @brief Timesync with NTP server
- * 
+ *
  * @return error status, false if successful, true if error
  */
 bool TimeSync(void);
@@ -74,7 +73,7 @@ bool Check(void);
 
 /**
  * @brief Setup upload timer
- * 
+ *
  * Start sensor measurements and setup upload task/timer.
  */
 void StartUploads(void);
@@ -117,8 +116,10 @@ void WiFiInit(void) {
   StartUploads();
 }
 
-void UploadEvent(void *context) {
-  UTIL_SEQ_SetTask((1 << CFG_SEQ_Task_WiFiUpload), CFG_SEQ_Prio_0);
+void UploadEvent(void* context) {
+  UTIL_SEQ_SetTask(
+      (1 << CFG_SEQ_Task_WiFiUpload),
+      CFG_SEQ_Prio_1);  // lower priority (higher value) than measure task
 }
 
 void Upload(void) {
@@ -133,26 +134,26 @@ void Upload(void) {
       APP_LOG(TS_OFF, VLEVEL_M, "Buffer empty!\r\n")
     } else {
       APP_LOG(TS_OFF, VLEVEL_M,
-          "Error getting data from fram buffer. FramStatus = %d\r\n", status);
+              "Error getting data from fram buffer. FramStatus = %d\r\n",
+              status);
     }
     return;
   }
 
   // print buffer
   APP_LOG(TS_ON, VLEVEL_M, "Payload[%d]: ", buffer_len);
-  for (int i = 0; i < buffer_len; i++)
-  {
+  for (int i = 0; i < buffer_len; i++) {
     APP_LOG(TS_OFF, VLEVEL_M, "%x ", buffer[i]);
   }
   APP_LOG(TS_OFF, VLEVEL_M, "\r\n");
- 
+
   // posts data to website
   APP_LOG(TS_ON, VLEVEL_M, "Uploading data.");
   if (!ControllerWiFiPost(buffer, buffer_len)) {
     APP_LOG(TS_OFF, VLEVEL_M, "Error! Could not communicate with esp32!\r\n");
   }
-    
-  for (unsigned int retries = 0;; retries++) { 
+
+  for (unsigned int retries = 0;; retries++) {
     HAL_Delay(retry_delay);
     APP_LOG(TS_OFF, VLEVEL_M, ".");
 
@@ -164,9 +165,13 @@ void Upload(void) {
     } else {
       // check category of error
       if (resp.http_code == 0) {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error when posting data! Likely error with WiFi or response timeout.\r\n");
+        APP_LOG(TS_OFF, VLEVEL_M,
+                "Error when posting data! Likely error with WiFi or response "
+                "timeout.\r\n");
       } else {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error with HTTP code! Likely error with measurement format or backend.\r\n");
+        APP_LOG(TS_OFF, VLEVEL_M,
+                "Error with HTTP code! Likely error with measurement format or "
+                "backend.\r\n");
       }
 
       // give up after max retries and tirgger error handler
@@ -176,9 +181,8 @@ void Upload(void) {
         return;
       }
     }
-
   }
-  
+
   if (FramBufferLen() > 0) {
     APP_LOG(TS_ON, VLEVEL_M, "Buffer not empty, starting another upload\r\n");
     UploadEvent(NULL);
@@ -195,12 +199,14 @@ void StartUploads(void) {
 
   // get upload period from user config
   const UserConfiguration* cfg = UserConfigGet();
-  UTIL_TIMER_Time_t UploadPeriod = cfg->Upload_interval * 1000; 
+  UTIL_TIMER_Time_t UploadPeriod = cfg->Upload_interval * 1000;
 
   // setup upload task
   APP_LOG(TS_ON, VLEVEL_M, "Starting upload task...\t")
   UTIL_SEQ_RegTask((1 << CFG_SEQ_Task_WiFiUpload), UTIL_SEQ_RFU, Upload);
-  UTIL_TIMER_Create(&UploadTimer, UploadPeriod, UTIL_TIMER_PERIODIC, UploadEvent, NULL);
+  UploadEvent(NULL);
+  UTIL_TIMER_Create(&UploadTimer, UploadPeriod, UTIL_TIMER_PERIODIC,
+                    UploadEvent, NULL);
   UTIL_TIMER_Start(&UploadTimer);
   APP_LOG(TS_OFF, VLEVEL_M, "Started!\r\n");
 }
@@ -239,35 +245,39 @@ bool Connect(void) {
 
   const char* ssid = cfg->WiFi_SSID;
   const char* passwd = cfg->WiFi_Password;
- 
+
   APP_LOG(TS_ON, VLEVEL_M, "Connecting to %s.", ssid);
   if (!ControllerWiFiConnect(ssid, passwd)) {
     APP_LOG(TS_OFF, VLEVEL_M, "Error! Could not communicate with esp32!\r\n");
     return false;
   }
 
-  for (unsigned int retries=0; ; retries++) {
+  for (unsigned int retries = 0;; retries++) {
     HAL_Delay(retry_delay);
     APP_LOG(TS_OFF, VLEVEL_M, ".")
 
     ControllerWiFiStatus status = ControllerWiFiCheckWiFi();
     if (status == CONTROLLER_WIFI_CONNECTED) {
       break;
-    } else if (status == CONTROLLER_WIFI_DISCONNECTED) {
-      continue;
     } else {
+      if (status == CONTROLLER_WIFI_DISCONNECTED) {
+        continue;
+      } else if (status == CONTROLLER_WIFI_NO_SSID_AVAIL) {
+        APP_LOG(TS_OFF, VLEVEL_M, "Error! No SSID available!\r\n");
+        return false;
+      } else if (status == CONTROLLER_WIFI_CONNECT_FAILED) {
+        APP_LOG(TS_OFF, VLEVEL_M, "Error! Connect failed!\r\n");
+        return false;
+      }
+
       if (retries >= max_retries) {
-        if (status == CONTROLLER_WIFI_NO_SSID_AVAIL) {
-          APP_LOG(TS_OFF, VLEVEL_M, "Error! No SSID available!\r\n");
-        } else if (status == CONTROLLER_WIFI_CONNECT_FAILED) {
-          APP_LOG(TS_OFF, VLEVEL_M, "Error! Connect failed!\r\n");
-        } else {
-          APP_LOG(TS_OFF, VLEVEL_M, "Error! Timeout after %d retries!\r\n", retries);
-        }
+        APP_LOG(TS_OFF, VLEVEL_M, "Error! Timeout after %d retries!\r\n",
+                retries);
         return false;
       }
     }
   }
+
   APP_LOG(TS_OFF, VLEVEL_M, "Connected!\r\n");
 
   return true;
@@ -280,7 +290,7 @@ bool Disconnect(void) {
     return false;
   }
 
-  for (unsigned int retries=0; ; retries++) {
+  for (unsigned int retries = 0;; retries++) {
     HAL_Delay(retry_delay);
     APP_LOG(TS_OFF, VLEVEL_M, ".")
 
@@ -291,7 +301,8 @@ bool Disconnect(void) {
       break;
     } else {
       if (retries >= max_retries) {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error! Timeout after %d retries!\r\n", retries);
+        APP_LOG(TS_OFF, VLEVEL_M, "Error! Timeout after %d retries!\r\n",
+                retries);
         return false;
       }
     }
@@ -310,24 +321,24 @@ bool TimeSync(void) {
     return false;
   }
 
-  for (unsigned int retries = 0; ; retries++) {
+  for (unsigned int retries = 0;; retries++) {
     HAL_Delay(retry_delay);
     APP_LOG(TS_OFF, VLEVEL_M, ".");
 
     ts.Seconds = ControllerWiFiTime();
-  
+
     // check for errors
     if (ts.Seconds != 0) {
       break;
     } else {
       if (retries >= max_retries) {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error! Timeout after %d retries!\r\n", retries);
+        APP_LOG(TS_OFF, VLEVEL_M, "Error! Timeout after %d retries!\r\n",
+                retries);
         return false;
       }
     }
+  }
 
-  } 
-  
   SysTimeSet(ts);
 
   APP_LOG(TS_OFF, VLEVEL_M, "Done!\r\n");
@@ -338,10 +349,10 @@ bool TimeSync(void) {
 
 bool Check(void) {
   const UserConfiguration* cfg = UserConfigGet();
-  
-  //const char url[] = "dirtviz.jlab.ucsc.edu";
-  //const uint32_t port = 80;
-  
+
+  // const char url[] = "dirtviz.jlab.ucsc.edu";
+  // const uint32_t port = 80;
+
   const char* url = cfg->API_Endpoint_URL;
 
   APP_LOG(TS_OFF, VLEVEL_M, "Checking API health.");
@@ -349,8 +360,8 @@ bool Check(void) {
     APP_LOG(TS_OFF, VLEVEL_M, "Error! Could not communicate with esp32!\r\n");
     return false;
   }
-  
-  for (unsigned int retries = 0;; retries++) { 
+
+  for (unsigned int retries = 0;; retries++) {
     APP_LOG(TS_OFF, VLEVEL_M, ".");
 
     ControllerWiFiResponse resp = ControllerWiFiCheckRequest();
@@ -361,9 +372,13 @@ bool Check(void) {
     } else {
       // check category of error
       if (resp.http_code == 0) {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error when posting data! Likely error with WiFi or response timeout.\r\n");
+        APP_LOG(TS_OFF, VLEVEL_M,
+                "Error when posting data! Likely error with WiFi or response "
+                "timeout.\r\n");
       } else {
-        APP_LOG(TS_OFF, VLEVEL_M, "Error with HTTP code! Likely error with measurement format or backend.\r\n");
+        APP_LOG(TS_OFF, VLEVEL_M,
+                "Error with HTTP code! Likely error with measurement format or "
+                "backend.\r\n");
       }
 
       // give up after max retries and tirgger error handler

--- a/stm32/lib/sensors/src/sensors.c
+++ b/stm32/lib/sensors/src/sensors.c
@@ -79,6 +79,7 @@ void SensorsInit(void) {
 void SensorsStart(void) {
   // start the timer
   UTIL_TIMER_Start(&MeasureTimer);
+  SensorsRun();
 }
 
 void SensorsStop(void) {
@@ -117,12 +118,16 @@ void SensorsMeasure(void) {
     }
     APP_LOG(TS_OFF, VLEVEL_M, "\r\n");
 
+    if (buffer_len == -1){
+      APP_LOG(TS_ON, VLEVEL_M, "Error: buffer_len == -1\r\n");
+      return;
+    }
     // add to tx buffer
     FramStatus status = FramPut(buffer, buffer_len);
     if (status == FRAM_BUFFER_FULL) {
-      APP_LOG(TS_OFF, VLEVEL_M, "Error: TX Buffer full!\r\n");
+      APP_LOG(TS_ON, VLEVEL_M, "Error: TX Buffer full!\r\n");
     } else if (status != FRAM_OK) {
-      APP_LOG(TS_OFF, VLEVEL_M, "Error: General FRAM buffer!\r\n");
+      APP_LOG(TS_ON, VLEVEL_M, "Error: General FRAM buffer!\r\n");
     }
   }
 }

--- a/stm32/lib/sensors/src/sensors.c
+++ b/stm32/lib/sensors/src/sensors.c
@@ -110,6 +110,12 @@ void SensorsMeasure(void) {
   for (int i = 0; i < callback_arr_len; i++) {
     // call measurement function
     buffer_len = callback_arr[i](buffer);
+
+    if (buffer_len == ((size_t)-1)) {
+      APP_LOG(TS_ON, VLEVEL_M, "Error: buffer_len == -1\r\n");
+      return;
+    }
+
     APP_LOG(TS_ON, VLEVEL_M, "Callback index: %d\r\n", i);
     APP_LOG(TS_ON, VLEVEL_M, "Buffer length: %u\r\n", buffer_len);
     APP_LOG(TS_ON, VLEVEL_M, "Buffer: ");
@@ -118,10 +124,6 @@ void SensorsMeasure(void) {
     }
     APP_LOG(TS_OFF, VLEVEL_M, "\r\n");
 
-    if (buffer_len == -1){
-      APP_LOG(TS_ON, VLEVEL_M, "Error: buffer_len == -1\r\n");
-      return;
-    }
     // add to tx buffer
     FramStatus status = FramPut(buffer, buffer_len);
     if (status == FRAM_BUFFER_FULL) {


### PR DESCRIPTION
**Name/Affiliation/Title**
Jack, UCSC, jLab researcher

**Purpose of the PR**
This PR enables the ENTS board to measure its sensors and attempt an upload immediately after connecting. The main benefit is that you no longer have to wait an entire upload interval for a successful upload if the initial tasks were sequenced such that the first upload task occurred prior to the first measure task (which would result in the upload being terminated due to no measurements in the buffer to upload). Having instant uploads helps to reduce the time needed to see if the board is functioning and uploading properly. 

**Development Environment**
Based off of firmware version 2.3.3, designed for hardware revision 2.2.3.

**Test Procedure**
To test, initialize a board as usual and load up the (wifi) userconfig using the `ents-gui` tool. Then, unplug the board and plug it back into power. Observe that the LED goes from slow blinking to fast blinking to off, and double check on the ents-backend (either on the website or via querying the database) that data was uploaded after power-on and wireless connection, regardless of the length of the upload interval.

**Additional Context**
This was developed during the Northwestern University deployment to reduce the time spent on monitoring whether boards uploaded correctly or not.

**Task List**

- [ ] Update `CHANGELOG.md`
- [ ] Static code analysis passes
- [ ] All environments can be built
- [x] All tests pass
- [ ] Clear documentation for new code
- [ ] Linting passes
- [ ] (If applicable) Version bump python library

**Relevant Issues**
none